### PR TITLE
Show a message when the window doesn't have focus.

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -375,7 +375,7 @@ Vue.component('call_display', {
 
 
 // The focus_display indicated when the window has lost focus
-Vue.component('call_display', {
+Vue.component('focus_display', {
 
     // data in components should be a function, to maintain scope
 	data: function(){
@@ -1157,5 +1157,4 @@ bell_circle = new Vue({
 // 	console.log(msg)
 // 	message_display.messages.push('<b>' + msg.user_name + '</b>: ' + msg.message)
 // });
-
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -374,6 +374,39 @@ Vue.component('call_display', {
 }); // end call_display component
 
 
+// The focus_display indicated when the window has lost focus
+Vue.component('call_display', {
+
+    // data in components should be a function, to maintain scope
+	data: function(){
+		return { visible: true };
+	},
+
+    mounted: function() {
+        this.$nextTick(function() {
+            window.addEventListener('focus', this.hide)
+            window.addEventListener('blur', this.show)
+
+            document.hasFocus() ? this.hide() : this.show()
+        })
+    },
+
+    methods: {
+        show() {
+            this.visible = true;
+        },
+        hide() {
+            this.visible = false;
+        }
+    },
+
+	template: `<h2 v-show="visible" id='focus_display'>
+                   Click anywhere in Ringing Room to resume ringing.
+               </h2>
+              `
+}); // end focus_display component
+
+
 // tower_controls holds title, id, size buttons, audio toggle
 Vue.component('tower_controls', {
 
@@ -1029,6 +1062,7 @@ bell_circle = new Vue({
                             number_of_bells == 10 ? 'ten'    : '',
                             number_of_bells == 12 ? 'twelve' : '']">
             <call_display v-bind:audio="audio" ref="display"></call_display>
+            <focus_display ref="focus"></focus_display>
               <bell_rope v-for="bell in bells"
                          v-bind:key="bell.number"
                          v-bind:number="bell.number"

--- a/app/static/sass/circle.scss
+++ b/app/static/sass/circle.scss
@@ -76,6 +76,18 @@
         transform: translate(-50%,-50%);
     }
 
+    #focus_display {
+        position: absolute;
+        text-align: center;
+        top: 70%;
+        left: 50%;
+        width: 80%;
+        padding: 10%;
+        transform: translate(-50%,0);
+        background-color: $text-color;
+        color: $body-bg;
+    }
+
 
     .bell_circle {
       $circ-size: $media-circ-size;


### PR DESCRIPTION
I've made the message fairly bold, going for clarity over subtlety or style.

Tested in Firefox, Chrome, Safari.

Issue #67 
<img width="805" alt="Screenshot 2020-05-13 at 16 23 34" src="https://user-images.githubusercontent.com/1766512/81832190-1d442800-9536-11ea-895d-eb21e038defa.png">
