### PR TITLE
Bugfix reset failure page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -230,12 +230,10 @@ def reset_password(token):
     if current_user.is_authenticated:
         return redirect(url_for('index'))
     user = User.verify_reset_password_token(token)
-    if not user:
-        return redirect(url_for('index'))
     form = ResetPasswordForm()
     if form.validate_on_submit():
         user.set_password(form.password.data)
         db.session.commit()
         flash('Your password has been reset.')
         return redirect(url_for('authenticate'))
-    return render_template('reset_password.html', form=form)
+    return render_template('reset_password.html', form=form, token_success=bool(user))

--- a/app/templates/email/reset_password.html
+++ b/app/templates/email/reset_password.html
@@ -2,13 +2,11 @@
 
 <p>
     To reset your password
-    <a href="{{ url_for('reset_password', token=token, _external=True) }}">
-        click here
-    </a>.
+    <a href="{{ url_for('reset_password', token=token, _external=True) }}">click here</a>.
 </p>
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>
 <p>{{ url_for('reset_password', token=token, _external=True) }}</p>
-<p>If you have not requested a password reset simply ignore this message. Please note that this link will expire after 1 hour.</p>
+<p>If you have not requested a password reset simply ignore this message. Please note that this link will expire after 24 hours.</p>
 
 <p>Cheers,</p>
 <p>The Ringing Room Team</p>

--- a/app/templates/email/reset_password.txt
+++ b/app/templates/email/reset_password.txt
@@ -1,10 +1,10 @@
 Dear {{user.username}},
 
-To reset your password, click on the following link:
+To reset your password, put the following URL into your browser's location bar:
 
 {{url_for('reset_password',token=token, _external=True)}}
 
-If you have not requested a password reset simply ignore this message. Please note that this link will expire after 1 hour.
+If you have not requested a password reset simply ignore this message. Please note that this link will expire after 24 hours.
 
 Cheers,
 

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -2,7 +2,10 @@
 
 {% block app_content %}
 
+
 <h1>Reset Your Password</h1>
+
+{% if token_success %}
 
 <form action="" method="post">
     {{form.hidden_tag()}}
@@ -31,5 +34,12 @@
 </div>
 
 </form>
+
+{% else %}
+
+The password reset link you clicked was invalid. The link expires 24 hours after the email was sent, so you may need to resend it.
+
+
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
If a user tries to use an invalid (e.g. expired) password-reset link, they will be directed to a page explaining that they've used an invalid link and that links expire after 24 hours. (The old behavior was to silently redirect to the front page.)