### PR TITLE
Handle anonymous user leaving the tower

### DIFF
--- a/app/listeners.py
+++ b/app/listeners.py
@@ -148,8 +148,14 @@ def on_user_left(json):
             user_id = jwt.decode(json['user_token'],app.config['SECRET_KEY'],algorithms=['HS256'])['id']
             user = load_user(user_id)
         except:
-            user_id = session['user_id']
+            user_id = session.get('user_id')
             pass # leave user set to None
+    else:
+        user_id = session.get('user_id')
+        pass # leave user set to None
+
+    if user_id is None:
+        return
 
     if not user:
         tower.remove_observer(user_id)


### PR DESCRIPTION
Ensures user_id is assigned.
user_id will be `None` if the key doesn't exist in session

Fixes #124