### PR TITLE
Left-right keys work for non-consecutive pairs of bells

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -2,6 +2,10 @@
 /* SETUP */
 ///////////
 
+// Constants
+const LEFT_HAND = "left";
+const RIGHT_HAND = "right";
+
 // Don't log unless needed
 var logger = function() {
     var oldConsoleLog = null;
@@ -1232,12 +1236,12 @@ You can read more on our <a href="/help">Help page</a>.
                     const n_b = bell_circle.number_of_bells;
                     // Space, j, and ArrowRight ring the bell in position n/2
                     if ([' ', 'j', 'J', 'ArrowRight'].includes(key)) {
-                        bell_circle.pull_rope_by_pos(1);
+                        bell_circle.pull_rope_by_hand(RIGHT_HAND);
                     }
 
                     // f and ArrowLeft ring the bell in position n/2 + 1
                     if (['f', 'F', 'ArrowLeft'].includes(key)) {
-                        bell_circle.pull_rope_by_pos(2);
+                        bell_circle.pull_rope_by_hand(LEFT_HAND);
                     }
 
                     // Calls are: g = go; h = stop; b = bob; n = single.
@@ -1350,6 +1354,17 @@ You can read more on our <a href="/help">Help page</a>.
                         this.pull_rope(this.bells[bell]['number']);
                         return true;
                     }
+                }
+            },
+
+            // Pull the 'left' or 'right' hand bell
+            pull_rope_by_hand: function(hand) {
+                if (hand == LEFT_HAND) {
+                    this.pull_rope_by_pos(2);
+                } else if (hand == RIGHT_HAND) {
+                    this.pull_rope_by_pos(1);
+                } else {
+                    console.warn("Unknown hand used: '" + hand + "'.");
                 }
             },
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1370,8 +1370,6 @@ You can read more on our <a href="/help">Help page</a>.
                     }
                 }
 
-                console.log(current_user_bells);
-
                 // Use these to decide which bells should be in the user's left and right hands
                 if (current_user_bells.length == 0) {
                     // If no bells are assigned, fall back to the behaviour of 'left' and 'right'

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1359,6 +1359,13 @@ You can read more on our <a href="/help">Help page</a>.
 
             // Pull the 'left' or 'right' hand bell
             pull_rope_by_hand: function(hand) {
+                // Drop out of this function if `hand` is invalid
+                if (!hand || (hand !== LEFT_HAND && hand !== RIGHT_HAND)) {
+                    console.error("Unknown value of 'hand': '" + hand + "'.");
+
+                    return;
+                }
+
                 // Collect the numbers of the bells that belong to the current user
                 let current_user_bells = [];
 
@@ -1370,20 +1377,71 @@ You can read more on our <a href="/help">Help page</a>.
                     }
                 }
 
-                // Use these to decide which bells should be in the user's left and right hands
+                /* Use these to decide which bells should be in the user's left and right hands. */
+                // CASE 1: No bells are assigned
                 if (current_user_bells.length == 0) {
                     // If no bells are assigned, fall back to the behaviour of 'left' and 'right'
                     // being the two bells on the bottom of the screen
                     if (hand == LEFT_HAND) {
                         this.pull_rope_by_pos(2);
-                    } else if (hand == RIGHT_HAND) {
+                    } else {
                         this.pull_rope_by_pos(1);
                     }
-                } else if (current_user_bells.length >= 2 && hand === LEFT_HAND) {
-                    this.pull_rope(current_user_bells[1]);
-                } else if (current_user_bells.length >= 1 && hand === RIGHT_HAND) {
+                }
+
+                // CASE 2: Only one bell is assigned.
+                // In this case, we should assign it to the right hand, and ignore the left hand
+                // key presses
+                if (current_user_bells.length == 1 && hand === RIGHT_HAND) {
                     this.pull_rope(current_user_bells[0]);
                 }
+
+                // CASE 3: Exactly two bells are defined.
+                // In this case, we should pair them up the shortest possible way, even if this
+                // would wrap over the 'end' of the circle, and assign them as though we are
+                // looking in from the outside of the circle
+                if (current_user_bells.length == 2) {
+                    // Put the first and second bell (by number) into two variables for ease of use
+                    const first_bell = current_user_bells[0];
+                    const second_bell = current_user_bells[1];
+
+                    // Decide on which way round the bells should be
+                    var left_hand_bell;
+                    var right_hand_bell;
+
+                    if (second_bell - first_bell < first_bell + this.bells.length - second_bell) {
+                        // The shortest way to pair the bells does not wrap round the 'end' of the
+                        // circle
+                        left_hand_bell = second_bell;
+                        right_hand_bell = first_bell;
+                    } else {
+                        // The shortest way to pair the bells *does* wrap round the 'end' of the
+                        // circle
+                        left_hand_bell = first_bell;
+                        right_hand_bell = second_bell;
+                    }
+
+                    // We know that hand is one of `LEFT_HAND` or `RIGHT_HAND` because
+                    // otherwise the function would have returned early
+                    if (hand === LEFT_HAND) {
+                        this.pull_rope(left_hand_bell);
+                    } else {
+                        this.pull_rope(right_hand_bell);
+                    }
+                }
+
+                // CASE 4: There are more than 2 bells assigned.
+                // In this case, it is badly defined what bells to ring, so we ring the two lowest
+                // numbered bells since this will make sense most of the time.
+                if (current_user_bells.length > 2) {
+                    // We know that hand is one of `LEFT_HAND` or `RIGHT_HAND` because
+                    // otherwise the function would have returned early
+                    if (hand === LEFT_HAND) {
+                        this.pull_rope(current_user_bells[1]);
+                    } else {
+                        this.pull_rope(current_user_bells[0]);
+                    }
+                } 
             },
 
             // emit a call

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1359,12 +1359,32 @@ You can read more on our <a href="/help">Help page</a>.
 
             // Pull the 'left' or 'right' hand bell
             pull_rope_by_hand: function(hand) {
-                if (hand == LEFT_HAND) {
-                    this.pull_rope_by_pos(2);
-                } else if (hand == RIGHT_HAND) {
-                    this.pull_rope_by_pos(1);
-                } else {
-                    console.warn("Unknown hand used: '" + hand + "'.");
+                // Collect the numbers of the bells that belong to the current user
+                let current_user_bells = [];
+
+                for (var i = 0; i < this.$refs.bells.length; i++) {
+                    const bell = this.$refs.bells[i];
+
+                    if (bell.assigned_user === window.tower_parameters.cur_user_name) {
+                        current_user_bells.push(bell.number);
+                    }
+                }
+
+                console.log(current_user_bells);
+
+                // Use these to decide which bells should be in the user's left and right hands
+                if (current_user_bells.length == 0) {
+                    // If no bells are assigned, fall back to the behaviour of 'left' and 'right'
+                    // being the two bells on the bottom of the screen
+                    if (hand == LEFT_HAND) {
+                        this.pull_rope_by_pos(2);
+                    } else if (hand == RIGHT_HAND) {
+                        this.pull_rope_by_pos(1);
+                    }
+                } else if (current_user_bells.length >= 2 && hand === LEFT_HAND) {
+                    this.pull_rope(current_user_bells[1]);
+                } else if (current_user_bells.length >= 1 && hand === RIGHT_HAND) {
+                    this.pull_rope(current_user_bells[0]);
                 }
             },
 


### PR DESCRIPTION
Closes #140.

This now has 4 cases to decide which bells should be assigned to the `left` and `right` keys:

**Case 1** - _no_ bells are assigned to the current user:
- Use the current behaviour of ringing the two bells at the bottom of the screen

**Case 2** - _1_ bell is assigned to the current user:
- This bell will be the `right` hand bell, and the `left` hand key will do nothing.  This is the only really user-noticeable change from this PR, but I think it makes more sense than the `left` key potentially ringing a bell assigned to someone else.

**Case 3** -  _2_ bells are assigned to the current user:
- These two bells will be assigned to the `left` and `right` keys, regardless of whether or not they are next to each other and how the user's view is aligned.  It will always assign them as though the user is sitting between them (going the shortest distance round the circle).  Therefore, if the `1` and `8` are assigned (for ringing `Major`), then the `right` key will ring the `8` and the `left` key will ring the `1`.

**Case 4** - _more than 2_ bells are assigned to the current user:
- The `right` key will ring the numerically lowest of these bells, and the `left` key will ring the second numerically lowest of these bells.  I don't expect this to happen very much since there are only two keys to ring bells from, but in case it does it's quite badly defined how to assign them - so I've gone with this solution on the basis that it's easy to implement and understand.
