### PR TITLE
Prioritise memorable tower IDs

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -256,11 +256,14 @@ class Tower:
 
     def generate_random_change(self):
         # generate a random caters change, for use as uid
-        tmp_tower_id = int(''.join(map(str, sample([i+1 for i in range(9)], k=9))))
+        def generate_candidate():
+            return int(''.join(map(str, sample([i+1 for i in range(9)], k=9))))
+
+        tmp_tower_id = generate_candidate()
         overlapping_tower_ids = TowerDB.query.filter_by(tower_id=tmp_tower_id)
 
         while not overlapping_tower_ids.count() == 0:
-            tmp_tower_id = int(''.join(map(str, sample([i + 1 for i in range(9)], k=9))))
+            tmp_tower_id = generate_candidate()
             overlapping_tower_ids = TowerDB.query.filter_by(tower_id=tmp_tower_id)
 
         return tmp_tower_id

--- a/app/models.py
+++ b/app/models.py
@@ -243,6 +243,7 @@ class Tower:
             self._id = self.generate_random_change()
         else:
             self._id = tower_id
+
         self._name = name
         self._n = 8
         self._bell_state = [True] * n

--- a/app/models.py
+++ b/app/models.py
@@ -283,12 +283,19 @@ class Tower:
 
             return int(''.join(map(str, [i+1 for i in new_row])))
 
-        tmp_tower_id = generate_candidate()
+        attempted_ids = 0
+
+        # The formula as the argument to generate_candidate is there to ensure that if too many
+        # tower ID collisions are found, the changes get steadily more random to prevent
+        # unnecessary load on the database
+        tmp_tower_id = generate_candidate(4 + attempted_ids // 5)
         overlapping_tower_ids = TowerDB.query.filter_by(tower_id=tmp_tower_id)
 
         while not overlapping_tower_ids.count() == 0:
-            tmp_tower_id = generate_candidate()
+            tmp_tower_id = generate_candidate(4 + attempted_ids // 5)
             overlapping_tower_ids = TowerDB.query.filter_by(tower_id=tmp_tower_id)
+
+            attempted_ids += 1
 
         return tmp_tower_id
 

--- a/app/models.py
+++ b/app/models.py
@@ -257,6 +257,8 @@ class Tower:
 
     # generate a random caters change, for use as uid
     def generate_random_change(self):
+        # Helper function to generate a potentially good change for a tower ID, given how
+        # much of the change it is required to shuffle.
         def generate_candidate(shuffle_length):
             # Generate rounds as a base change
             new_row = list(range(9))

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from app import db, log, login
 from config import Config
-from random import sample, randint
+from random import shuffle, sample, randint
 import re
 from datetime import datetime, timedelta, date
 from time import time


### PR DESCRIPTION
This PR changes the tower ID generation to prioritise musical and memorable changes as new tower IDs.  To be precise, it will try to generate changes that contain a 5-bell run off one end of the change (there are about ~500 changes like this).

To prevent overworking the database, if it tries 5 consecutive attempts and gets 5 IDs that already exists it reduces its requirement to only 4-bell runs (massively increasing the search space and the probability of future collisions).  It will keep reducing the requirements every 5 attempts until it just picks a change randomly.