### PR TITLE
Set at hand hotkey

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1195,6 +1195,11 @@ You can read more on our <a href="/help">Help page</a>.
                         e.preventDefault();
                     }
 
+                    // Shift-S will set the bells at hand
+                    if (e.shiftKey && e.which == 83) {
+                        bell_circle.set_bells_at_hand()
+                    }
+
                     // The numberkeys 1-0 ring those bells, with -, = ringing E, T
                     if (parseInt(key) - 1 in [...Array(9).keys()]) {
                         bell_circle.pull_rope(parseInt(key));

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -736,7 +736,8 @@ $(document).ready(function() {
     <li><b>[LEFT] and [RIGHT] arrow keys:</b> Rings the left and right bottom-most bells.</li>
     <li><b>[f] and [j]:</b> same as [LEFT] and [RIGHT]</li>
     <li><b>[SHIFT]+[0-9]\\[0]\\[-]\\[=]:</b> Rotate the "perspective" of the ringing room to put that bell in the lower right corner so it may be rung by [SPACE] or [j].</li>
-    <li> <b>[1-9], [0], [-], [=]:</b> Rings bells 1 - 9, 10, 11, and 12</li>
+    <li><b>[1-9], [0], [-], [=]:</b> Rings bells 1 - 9, 10, 11, and 12</li>
+    <li><b>[SHIFT]+[S]:</b> Set the bells at handstroke</li>
 </ul>
 
 <p> The tower controls allow you to set the number of bells, change whether you're using towerbell or handbell images and sounds, and set all the bells at hand.</p>

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -581,13 +581,7 @@ $(document).ready(function() {
             },
 
             set_bells_at_hand: function() {
-                if (window.tower_parameters.anonymous_user) {
-                    return
-                }; // don't do anything if not logged in
-                console.log('setting all bells at hand')
-                socketio.emit('c_set_bells', {
-                    tower_id: cur_tower_id
-                });
+                bell_circle.set_bells_at_hand();
             },
         },
 
@@ -1400,6 +1394,16 @@ You can read more on our <a href="/help">Help page</a>.
                         return a['position'] - b['position'];
                     }
                 );
+            },
+
+            set_bells_at_hand: function() {
+                if (window.tower_parameters.anonymous_user) {
+                    return
+                }; // don't do anything if not logged in
+                console.log('setting all bells at hand')
+                socketio.emit('c_set_bells', {
+                    tower_id: cur_tower_id
+                });
             },
 
             toggle_controls: function() {


### PR DESCRIPTION
Makes `shift+S` set the bells at handstroke, because moving the mouse is so inconvenient `;)`.  I'm happy to change the keybinding to something else if you want - `shift+S` seemed easy to remember and do, but hard to press by accident whilst ringing.