### PR TITLE
Add explicit mime types for .js / .css

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import logging
+import mimetypes
 from logging.handlers import RotatingFileHandler
 from flask import Flask, has_request_context, request, session
 from flask_sqlalchemy import SQLAlchemy
@@ -17,7 +18,7 @@ app.config.from_object(Config)
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 assets = Environment(app)
-socketio = SocketIO(app, 
+socketio = SocketIO(app,
                     logging=True,
                     cors_allowed_origins='*')
 login = LoginManager(app)
@@ -63,7 +64,7 @@ def log(*args):
 bundles = {
 
     'js_landing':   Bundle( 'landing.js',
-                            filters='jsmin', 
+                            filters='jsmin',
                             output='gen/landing.%(version)s.js'),
 
     'js_rr':        Bundle('ringing_room.js',
@@ -80,6 +81,8 @@ bundles = {
                          output='gen/rr.%(version)s.css'),
 
 }
+mimetypes.add_type('text/css', '.css')
+mimetypes.add_type('application/javascript', '.js')
 
 assets.register(bundles)
 


### PR DESCRIPTION
On Windows mimetypes looks in registry which seems to revert to `text/plain` and so is blocked by Chrome.