### PR TITLE
Fix import in add_host_column

### DIFF
--- a/migrations/versions/ecf0969f42be_add_host_column.py
+++ b/migrations/versions/ecf0969f42be_add_host_column.py
@@ -7,7 +7,7 @@ Create Date: 2020-06-11 08:39:47.620975
 """
 from alembic import op
 import sqlalchemy as sa
-from app import db
+from app.extensions import db
 from app.models import UserTowerRelation
 
 


### PR DESCRIPTION
`flask db upgrade` errors 
```
  File "D:\Development\virtual-ringing-room\migrations\versions\ecf0969f42be_add_host_column.py", line 10, in <module>
    from app import db
ImportError: cannot import name 'db' from 'app' (D:\Development\virtual-ringing-room\app\__init__.py)

```